### PR TITLE
Fixed a bug in ReadLineAsync

### DIFF
--- a/rskibbe.IO.Ports/SerialPortExtensions.cs
+++ b/rskibbe.IO.Ports/SerialPortExtensions.cs
@@ -19,6 +19,7 @@ public static class SerialPortExtensions
             var completed = StringBuilderEndsWith(sb, serialPort.NewLine);
             if (completed)
             {
+                response = sb.ToString();
                 response = response.Substring(0, response.Length - serialPort.NewLine.Length);
                 break;
             }
@@ -39,6 +40,7 @@ public static class SerialPortExtensions
             var completed = StringBuilderEndsWith(sb, serialPort.NewLine);
             if (completed)
             {
+                response = sb.ToString();
                 response = response.Substring(0, response.Length - serialPort.NewLine.Length);
                 break;
             }


### PR DESCRIPTION
I fixed a bug in the two ReadLineAsync methods where the response wasn't getting pulled from the stringbuilder before being truncated.  